### PR TITLE
Fix README-listed function issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ hs = pyseq.HiSeq(xCOM='COM67', yCOM='COM68', fpgaCOM=['COM10', 'COM11'], laser1C
 # Basic setup of HiSeq
 
 ```python
-hs.l1.set_power(100)                #Set green laser power to 100 mW
-hs.l2.set_power(100)                #Set red laser power to 100 mW
+hs.lasers['green'].set_power(100)                #Set green laser power to 100 mW
+hs.lasers['red'].set_power(100)                #Set red laser power to 100 mW
 
 hs.y.move(-180000)                  #Move stage to top right corner of Flow Cell A
 hs.x.move(17571)
@@ -56,11 +56,11 @@ hs.z.move([21250, 21250, 21250])    #Raise z stage
 
 hs.obj.move(30000)                  #Move objective to middle-ish
 
-hs.move_ex(1,'open')                #Move excitation filter 1 to open position
-hs.move_ex(2,'open')                #Move excitation filter 2 to open position
+hs.optics.move_ex('green','open')                #Move excitation filter 1 to open position
+hs.optics.move_ex('red','open')                #Move excitation filter 2 to open position
 
-hs.l1.get_power()                   #Get green laser power (mW i think)
-hs.l2.get_power()                   #Get red laser power   (mW i think)
+hs.lasers['green'].get_power()                   #Get green laser power (mW i think)
+hs.lasers['red'].get_power()                   #Get red laser power   (mW i think)
 ```
 
 # Image acquisition
@@ -73,7 +73,7 @@ Images and metafile are saved in the directory set in `hs.image_path`.
 hs.image_path = 'C:\\Users\\Public\\Documents\\PySeq2500\\Images\\'
 
 # Take an image
-hs.take_picture(32, 128) # take_picture(# frames, bundle height, image_name)
+hs.take_picture(32) # take_picture(# frames, image_name)
 ```
 
 Names of the images are `hs.cam1.left_emission + image_name`. The name of the metafile is just `image_name`. The `image_name`
@@ -111,11 +111,11 @@ Before taking a picture, the laser power should be set, the excitation filters s
 ## Lasers
 
 ```python
-hs.l1.set_power(100) # sets laser 1 (green) to 100 mW
-hs.l2.set_power(100) # sets laser 2 (red) to 100 mW
+hs.lasers['green'].set_power(100) # sets laser 1 (green) to 100 mW
+hs.lasers['red'].set_power(100) # sets laser 2 (red) to 100 mW
 
-hs.l1.get_power() # returns the power of laser 1 and stores it in hs.l1.power
-hs.l2.get_power() # returns the power of laser 2 and stores it in hs.l2.power
+hs.lasers['green'].get_power() # returns the power of laser 1 and stores it in hs.l1.power
+hs.lasers['red'].get_power() # returns the power of laser 2 and stores it in hs.l2.power
 ```
 
 During `hs.initializeInstruments()`, both lasers are set to 10 mW
@@ -125,7 +125,7 @@ During `hs.initializeInstruments()`, both lasers are set to 10 mW
 During `hs.initializeInstruments()`, the excitation filters are homed to the block position and the emission filter is moved into the light path.
 
 ```python
-hs.optics.move_ex(N, filter)		#  moves the excitation filter wheel in the N (1 or 2) light path to the filter.
+hs.optics.move_ex(color, filter)		#  moves the excitation filter wheel in the color ('green' or 'red') light path to the filter.
 hs.optics.ex_dict 					# stores the positions and names of the filters in a dictionary
 hs.optics.move_em_in(True/False) 	# "True" moves the emission filter into the light path, False moves it out.
 ```

--- a/pyseq/ystage.py
+++ b/pyseq/ystage.py
@@ -147,13 +147,14 @@ class Ystage():
             - int: 1 if ystage is in position, 0 if it is not in position.
 
         """
+        # TODO: could instead use self.command('TR(IP,=,1)') to wait for move to finish
         
         try:
             ip = int(self.command('R(IP)')[1:])
         except:
             ip = 0
 
-        return
+        return ip
 
 
     def read_position(self):


### PR DESCRIPTION
I started testing some of the commands listed in the README on our machine, ran into a few issues that should be fixed here:
- there was a missing return variable in the pyseq.ystage.check_position() command, which left initialization stuck in a loop
- looks like a few functions and argument names have changed since the README was written, correcting what I ran into here